### PR TITLE
Fix typescript error TS7016: Could not find a declaration file for module 'vue3-easymde'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,8 +23,14 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/vue-easymde.es.js",
-      "require": "./dist/vue-easymde.umd.js"
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/vue-easymde.es.js"
+      },
+      "require": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/vue-easymde.umd.js"
+      }
     }
   },
   "scripts": {


### PR DESCRIPTION
I got this error when using vue3-easymde on a new Vue project created with `npm create vue@latest` and run `npm run type-check`.

```
error TS7016: Could not find a declaration file for module 'vue3-easymde'. '{project_path}/node_modules/vue3-easymde/dist/vue-easymde.es.js' implicitly has an 'any' type.
  There are types at '{project_path}/node_modules/vue3-easymde/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue3-easymde' library may need to update its package.json or typings.
```

![2023-08-07-1021-Code_8UBeY2AZco](https://github.com/vikingmute/vue3-easymde/assets/13524958/6b672bf8-9c8f-4d41-aa8d-570c96158f17)

Referenced issue: [microsoft/TypeScript#52363](https://github.com/microsoft/TypeScript/issues/52363)
I applied the [solution provided by cmdruid here](https://github.com/microsoft/TypeScript/issues/52363#issuecomment-1659179354).

When I applied this fix on node_modules/vue3-easymde/package.json and re-run npm run type-check, the error is gone.

